### PR TITLE
[FIX] partner_second_lastname: False value should be set on lastname2

### DIFF
--- a/partner_second_lastname/tests/test_name.py
+++ b/partner_second_lastname/tests/test_name.py
@@ -139,6 +139,18 @@ class PersonCase(TransactionCase):
                                    self.firstname),
         }
 
+    def test_firstname_last_wo_comma(self):
+        """Create a person setting his first name last and the order as 'last_first'"""
+        self.env['ir.config_parameter'].set_param(
+            'partner_names_order', 'last_first')
+        self.template = "%(last1)s %(last2)s %(first)s"
+        self.params = {
+            "is_company": False,
+            "name": "%s %s %s" % (self.lastname,
+                                  self.lastname2,
+                                  self.firstname),
+        }
+
     def test_firstname_only(self):
         """Create a person setting his first name only."""
         self.env['ir.config_parameter'].set_param(
@@ -168,6 +180,18 @@ class PersonCase(TransactionCase):
         self.params = {
             "is_company": False,
             "name": "%s, %s" % (self.lastname, self.firstname),
+        }
+
+    def test_lastname_firstname_only_wo_comma(self):
+        """Create a person setting his last name 1 and first name only.
+        Set order to 'last_first' to test name split without comma"""
+        self.env['ir.config_parameter'].set_param(
+            'partner_names_order', 'last_first')
+        self.lastname2 = False
+        self.template = "%(last1)s %(first)s"
+        self.params = {
+            "is_company": False,
+            "name": "%s %s" % (self.lastname, self.firstname),
         }
 
     def test_separately(self):


### PR DESCRIPTION
not firstname

before this commit the following error happen:
name = 'Van-Eyck Jan'

this was converted to

firstname = False
lastname= 'Van-Eyck'
lastname2 = 'Jan'

and it should be like

firstname = 'Jan'
lastname= 'Van-Eyck'
lastname2 = False

Cherry-pick from v10-11