### PR TITLE
[REF] partner_firstname: Support duplicate multiple names

### DIFF
--- a/partner_firstname/models/res_partner.py
+++ b/partner_firstname/models/res_partner.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 from .. import exceptions
 
@@ -31,8 +31,14 @@ class ResPartner(models.Model):
         """Add inverted names at creation if unavailable."""
         context = dict(self.env.context)
         name = vals.get("name", context.get("default_name"))
-
-        if name is not None:
+        if context.get("copy") and vals.get('firstname') and not vals.get('is_company'):
+            vals["firstname"] = _('%s (copy)', vals["firstname"])
+            # Remove the combined fields
+            if "name" in vals:
+                del vals["name"]
+            if "default_name" in context:
+                del context["default_name"]
+        elif name is not None:
             # Calculate the splitted fields
             inverted = self._get_inverse_name(
                 self._get_whitespace_cleaned_name(name),

--- a/partner_firstname/tests/base.py
+++ b/partner_firstname/tests/base.py
@@ -49,8 +49,11 @@ class BaseCase(TransactionCase, MailInstalled):
 
     def test_copy(self):
         """Copy the partner and compare the result."""
-        self.expect("%s (copy)" % self.lastname, self.firstname)
-        self.changed = self.original.with_context(copy=True, lang="en_US").copy()
+        self.changed = self.original.with_context(lang="en_US").copy()
+        if self.changed.is_company:
+            self.expect("%s (copy)" % self.lastname, self.firstname)
+        else:
+            self.expect(self.lastname, "%s (copy)" % self.firstname)
 
     def test_one_name(self):
         """Test what happens when only one name is given."""


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Considering following name:

firstname = Francisco Javier
lastname = Garcia
second_lastname = Cabeza de Vaca

When duplicate:

firstname = de Vaca Francisco Javier (copy)
lastname = Garcia
second_lastname = Cabeza

It is inverted based on the 'name' and changed the order of the fields

But when we are duplicating a contact we don't need to recompute the names since that it should be duplicated as it

Video:

https://youtu.be/CEFik5COK18

Current behavior before PR:

Duplicate partner with multiple last name or second last name, name is inverted based on the 'name'

Desired behavior after PR is merged:

Duplicate partner with multiple last name or second last name, name is not inverted.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr