### PR TITLE
[FIX] partner_company_default: No default company for module data

### DIFF
--- a/partner_company_default/models/res_partner.py
+++ b/partner_company_default/models/res_partner.py
@@ -12,10 +12,11 @@ class ResPartner(models.Model):
 
     @api.model
     def _default_company_id(self):
-        """Return False for other tests or if creating a company."""
+        """Return False for other tests, module data or if creating a company."""
         context = self.env.context
         if (
             context.get("creating_from_company")
+            or context.get("install_mode")
             or config["test_enable"]
             and not context.get("test_partner_company_default")
         ):

--- a/partner_company_default/tests/test_partner_company_default.py
+++ b/partner_company_default/tests/test_partner_company_default.py
@@ -44,3 +44,13 @@ class TestPartnerCompanyDefault(common.TransactionCase):
             .create({"name": "Test Partner 2"})
         )
         self.assertEqual(partner.company_id, company_fr)
+
+    def test_partner_company_default_install_mode(self):
+        """Check company of a partner created while loading the data of a module."""
+        partner = (
+            self.env["res.partner"]
+            .with_user(self.user.id)
+            .with_context(test_partner_company_default=True, install_mode=True)
+            .create({"name": "Test Partner 3"})
+        )
+        self.assertFalse(partner.company_id)

--- a/partner_multi_relation/models/res_partner_relation.py
+++ b/partner_multi_relation/models/res_partner_relation.py
@@ -70,11 +70,13 @@ class ResPartnerRelation(models.Model):
     this_partner_id = fields.Many2one(
         comodel_name="res.partner",
         compute="_compute_this_partner_id",
+        search="_search_any_partner_id",
         help="Partner shown left when no currently active partner",
     )
     other_partner_id = fields.Many2one(
         comodel_name="res.partner",
         compute="_compute_other_partner_id",
+        search="_search_any_partner_id",
         help="Partner shown right when no currently active partner"
         ", or connected partnes as seen from current partner.",
     )


### PR DESCRIPTION
A partner created while a module loads its data or demo files was getting the company of the environment.

The demo company of a localization is declared as a plain `res.partner` record, before the `res.company` record that points at it ([l10n_ca/demo/demo_company.xml](https://github.com/odoo/odoo/blob/160fe5f59275d78bb231e96f660a4c1436577913/addons/l10n_ca/demo/demo_company.xml)), so `creating_from_company` is not set there and the partner of the demo company ended up owned by the main company.

[`res.partner.bank.company_id` is related to `partner_id.company_id`](https://github.com/odoo/odoo/blob/160fe5f59275d78bb231e96f660a4c1436577913/odoo/addons/base/models/res_bank.py#L101), so the demo bank account that `account` creates for that company belonged to the main company while its journal belonged to the demo one, and [`account.journal._check_bank_account`](https://github.com/odoo/odoo/blob/160fe5f59275d78bb231e96f660a4c1436577913/addons/account/models/account_journal.py#L595) raised:

```
ERROR odoo.addons.account.models.chart_template: Error while loading accounting demo data
...
odoo.exceptions.ValidationError: The bank account of a bank journal must belong to the same company (CA Company).
```

Records that come from the data files of a module declare the company they belong to, exactly like the two cases this default already steps aside for.

## Verified

`odoo-bin -i partner_company_default,l10n_ca --with-demo`, on the Odoo 19.0 image of the customer that hit this:

| | accounting demo | partner of `CA Company` |
|---|---|---|
| without this PR | `ValidationError` | `company_id = 1` (main company) |
| with this PR | loads clean | `company_id = NULL` |

The error only shows up outside the tests, since `test_enable` already returns False in this default. That is why a test-enabled CI never sees it and a plain install does.