### PR TITLE
[FIX] partner_multi_relation: make this_partner_id/other_partner_id searchable

### DIFF
--- a/partner_multi_relation/models/res_partner_relation.py
+++ b/partner_multi_relation/models/res_partner_relation.py
@@ -70,11 +70,13 @@ class ResPartnerRelation(models.Model):
     this_partner_id = fields.Many2one(
         comodel_name="res.partner",
         compute="_compute_this_partner_id",
+        search="_search_any_partner_id",
         help="Partner shown left when no currently active partner",
     )
     other_partner_id = fields.Many2one(
         comodel_name="res.partner",
         compute="_compute_other_partner_id",
+        search="_search_any_partner_id",
         help="Partner shown right when no currently active partner"
         ", or connected partnes as seen from current partner.",
     )


### PR DESCRIPTION
Cherry-pick of Nhomar's fix, authorship preserved, onto the current 19.0.

## What it does

`this_partner_id` and `other_partner_id` are computed, non-stored fields with
no search method. `any_partner_id` already declares
`search="_search_any_partner_id"`; this reuses that same method for the other
two. Two lines, no new code.

## Why

Odoo 19's `resolve_depends()` warns when a computed field's `@depends` chain
crosses a non-stored field that has no search method, because it cannot
determine which records to recompute when the dependency changes
(`odoo/orm/fields.py:840-848`).

Any downstream module declaring a `related="this_partner_id.<field>"` triggers
that warning on every registry setup. On our side it was emitting 412 warning
lines per test run.

## Notes

- The branch `19.0-migration-nghm` of this fork carries this same change; it
  was rebased onto the current 19.0 today, which is why its commit hash
  differs from the original.
- Not proposed upstream yet: there is no open PR in OCA/partner-contact with
  this change (checked by title and by content search for
  `_search_any_partner_id`). Worth sending there so we stop carrying it as a
  fork-only patch.
